### PR TITLE
Fixed formatting, move autograd before optimization

### DIFF
--- a/beginner_source/quickstart/autograd_tutorial.py
+++ b/beginner_source/quickstart/autograd_tutorial.py
@@ -38,10 +38,12 @@ loss = torch.nn.functional.binary_cross_entropy_with_logits(z,y)
 # optimize. Thus, we need to be able to compute the gradients of loss
 # function with respect to those variables. In orded to do that, we set
 # the ``requires_grad`` property of those tensors.
-# 
-#    **Note:** You can set the value of ``requires_grad`` when creating a
-#    tensor, or later by using ``x.requires_grad_(True)`` method.
-# 
+
+#######################################################################
+# .. note:: You can set the value of ``requires_grad`` when creating a
+#           tensor, or later by using ``x.requires_grad_(True)`` method.
+
+#######################################################################
 # A function that we apply to tensors to construct computational graph is
 # in fact an object of class ``Function``. This object knows how to
 # compute the function in the *forward* direction, and also how to compute
@@ -72,13 +74,15 @@ print(b.grad)
 
 
 ######################################################################
-# **Notes:** \* We can only obtain the ``grad`` properties for the leaf
-# nodes of the computational graph, which have ``requires_grad`` property
-# set to ``True``. For all other nodes in our graph gradients will not be
-# available. \* We can only perform gradient calculations using
-# ``backward`` once on a given graph, for performance reasons. If we need
-# to do several ``backward`` calls on the same graph, we need to pass
-# ``retain_graph=True`` to the ``backward`` call.
+# .. note::
+#   - We can only obtain the ``grad`` properties for the leaf
+#     nodes of the computational graph, which have ``requires_grad`` property
+#     set to ``True``. For all other nodes in our graph gradients will not be
+#     available.
+#   - We can only perform gradient calculations using
+#     ``backward`` once on a given graph, for performance reasons. If we need
+#     to do several ``backward`` calls on the same graph, we need to pass
+#     ``retain_graph=True`` to the ``backward`` call.
 # 
 
 
@@ -135,12 +139,13 @@ print("\nCall after zeroing gradients\n",inp.grad)
 # to compute the proper gradients, you need to zero out the ``grad``
 # property before. In real-life training an *optimizer* helps us to do
 # this.
-# 
-# **Note:** Previously we were calling ``backward()`` function without
-# parameters. This is essentially equivalent to calling
-# ``backward(torch.tensor(1.0))``, which is a useful way to compute the
-# gradients in case of a scalar-valued function, such as loss during
-# neural network training.
+
+######################################################################
+# .. note:: Previously we were calling ``backward()`` function without
+#           parameters. This is essentially equivalent to calling
+#           ``backward(torch.tensor(1.0))``, which is a useful way to compute the
+#           gradients in case of a scalar-valued function, such as loss during
+#           neural network training.
 # 
 
 
@@ -231,7 +236,7 @@ for i in range(15):
 # process, we will need to do a number of iterations to minimize the value
 # of **loss function**.
 # 
-# Next: Learn more about `saving, loading and running the model <save_run_load_tutorial.html>`_.
+# Next: Learn more about `how to use AutoGrad to train a neural network model <optimization_tutorial.html>`_.
 #
 
 ##################################################################

--- a/beginner_source/quickstart/build_model_tutorial.py
+++ b/beginner_source/quickstart/build_model_tutorial.py
@@ -14,7 +14,8 @@ Build Model Tutorial
 # The neural network modules layers will be added to it in the order they are passed in.
 # 
 # Another way to bulid this model is with a class 
-# using `nn.Module <https://pytorch.org/docs/stable/generated/torch.nn.Module.html)>`_
+# using `nn.Module <https://pytorch.org/docs/stable/generated/torch.nn.Module.html)>`_ This gives us more flexibility, because
+# we can construct layers of any complexity, including the ones with shared weights.
 #
 # Lets break down the steps to build this model below
 #

--- a/beginner_source/quickstart/optimization_tutorial.py
+++ b/beginner_source/quickstart/optimization_tutorial.py
@@ -4,21 +4,19 @@ Optimizing Model Parameters
 Now that we have a model and data it's time to train, validate and test our model by optimizating it's paramerters on our data! 
 
 To do this we need to understand a how to handle 5 core deep learning concepts in PyTorch
-1. Hyperparameters (learning rates, batch sizes, epochs etc)
-2. Optimization Loops
-3. Loss
-4. AutoGrad
-5. Optimizers 
+ 1. Hyperparameters (learning rates, batch sizes, epochs etc)
+ 2. Optimization Loops
+ 3. Loss
+ 4. AutoGrad
+ 5. Optimizers 
 
 Let's dissect these concepts one by one and look at some code at the end we'll see how it all fits together.
 
-
+Hyperparameters 
+-----------------
 """
 
 ######################################################
-# Hyperparameters 
-# -----------------
-#
 # Hyperparameters are adjustable parameters that let you control the model optimization process. For example, with neural networks, you can configure:
 #
 # - **Number of Epochs**- the number times iterate over the dataset to update model parameters

--- a/beginner_source/quickstart/tensor_tutorial.py
+++ b/beginner_source/quickstart/tensor_tutorial.py
@@ -25,9 +25,7 @@ print(f"Tensor={tensor}, Array={tensor.numpy()}")
 
 
 ######################################################################
-# .. note:: When using CPU for computations, tensors converted from arrays
-# share the same memory for data. Thus, changing the underlying array will
-# also affect the tensor.
+# .. note:: When using CPU for computations, tensors converted from arrays share the same memory for data. Thus, changing the underlying array will also affect the tensor.
 # 
 
 
@@ -88,13 +86,10 @@ print(z.size()) # Prints [3.0]
 # ~~~~~~~~~~~~~~~~~
 # 
 # Tensors support all basic arithmetic operations, which can be specified
-# in different ways: \* Using operators, such as ``+``, ``-``, etc. \*
-# Using functions such as ``add``, ``mult``, etc. Functions can either
-# return values, or store them in the specified ouput variable (using
-# ``out=`` parameter) \* In-place operations, which modify one of the
-# arguments. Those operations have ``_`` appended to their name, eg.
-# ``add_``.
-# 
+# in different ways:
+#  - Using operators, such as ``+``, ``-``, etc. \*
+#  - Using functions such as ``add``, ``mult``, etc. Functions can either return values, or store them in the specified ouput variable (using ``out=`` parameter)
+#  - In-place operations, which modify one of the arguments. Those operations have ``_`` appended to their name, eg. ``add_``.
 # Complete reference to all tensor operations can be found `in the
 # documentation <https://pytorch.org/docs/stable/torch.html>`__.
 # 
@@ -188,11 +183,11 @@ print(x.view(5,-1)) # will result in size 5x3
 
 ######################################################################
 # .. note:: ``view`` is similar to ``reshape`` operation in NumPy. There
-# is also a ``reshape`` method available in PyTorch, and it is more
-# powerful than ``view``, because it can also reshape non-contiguous
-# arrays by copying them to the new shape. However, in vast majority of
-# cases you can use ``view`` and make sure that no data copying occurs,
-# and the operation is always efficient.
+#           is also a ``reshape`` method available in PyTorch, and it is more
+#           powerful than ``view``, because it can also reshape non-contiguous
+#           arrays by copying them to the new shape. However, in vast majority of
+#           cases you can use ``view`` and make sure that no data copying occurs,
+#           and the operation is always efficient.
 # 
 
 

--- a/beginner_source/quickstart_tutorial.py
+++ b/beginner_source/quickstart_tutorial.py
@@ -4,11 +4,12 @@ PyTorch Quickstart
 
 The basic machine learning concepts in any framework should include: Working with data, Creating models, Optimizing Parameters, Saving and Loading Models. In this quickstart we will go through an example of an applied machine learning model using the FashionMNIST dataset that demonstrates these core steps using Pytorch.
 
+Working with data
+-----------------
 """
+
 ######################################################################
-# Working with data
-# -----------------
-# 
+#
 # PyTorch has two basic data primitives: ``DataSet`` and ``DataLoader``.
 # These ``DataSet`` objects include a ``transforms`` mechanism to
 # modify data in-place. Below is an example of how to load that data from the Pytorch open datasets and transform the data to a normalized tensor. 


### PR DESCRIPTION
* Fixed formatting in autograd, tensors, and also header formatting in main page and optimization
* In sequential navigation through tutorials, I put AutoGrad section before optimization, because it logically makes sense (you need autograd to understand optimization)
* I did not fix the order in the footer content in all pages - maybe we can think later how to make it #included into all pages.